### PR TITLE
Agreado de uuid y sus definiciones de tipo

### DIFF
--- a/src/content/9/es/part9c.md
+++ b/src/content/9/es/part9c.md
@@ -1240,7 +1240,20 @@ Si ahora intentamos crear una nueva entrada en el diario con campos no válidos 
 ### Ejercicios 9.12.-9.13.
 
 #### 9.12: Patientor backend, paso 5
-Cree un endpoint POST <i>/api/patients</i> para agregar pacientes. Asegúrese de que puede agregar pacientes también desde el frontend.
+Cree un endpoint POST <i>/api/patients</i> para agregar pacientes. Asegúrese de que puede agregar pacientes también desde el frontend. Puede crear ids únicos de tipo <i>string</i> usando la librería [uuid](https://github.com/uuidjs/uuid):
+
+```js
+import {v1 as uuid} from 'uuid'
+const id = uuid()
+```
+
+Agregado de definiciones de tipo de uuid:
+
+```js
+npm i --save-dev @types/uuid
+```
+<i>Posiblemente sea necesario reiniciar el IDE para que los tipos de uuid instalados sean detectados correctamente.</i>
+
 
 #### 9.13: Patientor backend, paso 6
 


### PR DESCRIPTION
Esto es necesario porque el array de pacientes no tiene id's numéricos sino en el formato 'd2773336-f723-11e9-8f0b-362b9e155667' y no sirve por lo tanto hacer lo de Math.max(...)+1 [indicado en esta parte](https://fullstackopen.com/es/part9/escribiendo_la_aplicacion_express#agregar-un-nuevo-diario).

Texto copiado y traducido desde: https://fullstackopen.com/en/part9/typing_the_express_app#exercises-9-12-9-13 y extendido para considerar los tipos de Typescript de uuid.