### PR TITLE
Update part1a.md

### DIFF
--- a/src/content/1/es/part1a.md
+++ b/src/content/1/es/part1a.md
@@ -312,7 +312,7 @@ React se ha configurado para generar mensajes de error bastante claros. A pesar 
 
 Es bueno recordar que en React es posible y vale la pena escribir comandos <em>console.log()</em> (que se imprimen en la consola) dentro de tu código. 
 
-También tenga en cuenta que **los nombres de los componentes de React deben estar en mayúscula**. Si intenta definir un componente de la siguiente manera 
+También tenga en cuenta que **los nombres de los componentes de React deben de tener la primera letra en mayúscula**. Si intenta definir un componente de la siguiente manera 
 
 ```js
 const footer = () => {


### PR DESCRIPTION
Translate "capitalized" in Spanish. Looks like you need to put all character capitalized, but it is just the first character. You need to write "Footer", not "FOOTER"... I think so...