### PR TITLE
Remove reference to master branch

### DIFF
--- a/src/content/3/es/part3a.md
+++ b/src/content/3/es/part3a.md
@@ -865,7 +865,7 @@ Si los datos guardados en la variable _body_ tienen la propiedad <i>important</i
 
 Puede encontrar el código para nuestra aplicación actual en su totalidad en la rama <i>part3-1</i> de [este repositorio de github](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1).
 
-Observe que la rama master del repositorio contiene el código de una versión posterior de la aplicación. El código para el estado actual de la aplicación se encuentra específicamente en la rama [part3-1](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1).
+El código para el estado actual de la aplicación se encuentra específicamente en la rama [part3-1](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1).
 
 ![](../../images/3/21.png)
 


### PR DESCRIPTION
Remove reference to master branch because it does not exist.
Instead, the default branch in the repository is part3-1.