### PR TITLE
Update build:ui target in part3b.md

### DIFF
--- a/src/content/3/es/part3b.md
+++ b/src/content/3/es/part3b.md
@@ -219,7 +219,7 @@ Para crear una nueva compilación de producción del frontend sin trabajo manual
 {
   "scripts": {
     //...
-    "build:ui": "rm -rf build && cd ../../osa2/materiaali/notes-new && npm run build --prod && cp -r build ../../../osa3/notes-backend/",
+    "build:ui": "rm -rf build && cd ../../osa2/materiaali/notes-new && npm run build && cp -r build ../../../osa3/notes-backend/",
     "deploy": "git push heroku main",
     "deploy:full": "npm run build:ui && git add . && git commit -m uibuild && npm run deploy",    
     "logs:prod": "heroku logs --tail"


### PR DESCRIPTION
Update "npm run build:ui" command content by removing "--prod" because it actually does not have any effect on the optimized production build result.

Flag --prod is not even mentioned on the documentation at https://create-react-app.dev/docs/production-build/